### PR TITLE
CalledProcessError when raxml outputs an error.

### DIFF
--- a/ipk.py
+++ b/ipk.py
@@ -302,13 +302,18 @@ def build_database(ar,
 
     command_str = " ".join(s for s in command)
     print(command_str)
-    p = subprocess.run(command_str, shell=True, check=True)
+    try:
+        p = subprocess.run(command_str, shell=True, check=True)
 
-    # clean after
-    subprocess.call(["rm", "-rf", hashmaps_dir])
+        # clean after
+        subprocess.call(["rm", "-rf", hashmaps_dir])
 
-    if p.returncode != 0:
-        raise RuntimeError(f"IPK returned error: {p.returncode}")
+        if p.returncode != 0:
+            raise RuntimeError(f"IPK returned error: {p.returncode}")
+
+    except subprocess.CalledProcessError:
+        pass
+
 
 
 if __name__ == "__main__":

--- a/ipk/include/ar.h
+++ b/ipk/include/ar.h
@@ -72,6 +72,7 @@ namespace ipk
             std::string binary_file;
             std::string tree_file;
             std::string alignment_file;
+            std::string num_threads;
 
             /// User-defined arguments for the AR software
             std::string ar_parameters;

--- a/ipk/src/ar.cpp
+++ b/ipk/src/ar.cpp
@@ -618,7 +618,7 @@ namespace ipk::ar
 
             if (result != 0)
             {
-                throw std::runtime_error("Error during ancestral reconstruction: exit code"
+                throw std::runtime_error("Error during ancestral reconstruction: exit code "
                                          + std::to_string(result));
             }
         }
@@ -710,7 +710,7 @@ namespace ipk::ar
 
             if (result != 0)
             {
-                throw std::runtime_error("Error during ancestral reconstruction: exit code"
+                throw std::runtime_error("Error during ancestral reconstruction: exit code "
                                          + std::to_string(result));
             }
         }
@@ -727,7 +727,7 @@ namespace ipk::ar
                 "--ancestral",
                 "--msa", _params.alignment_file,
                 "--tree", _params.tree_file,
-                "--threads", "1", //_params.threads,
+                "--threads", _params.num_threads,
                 "--precision", "9",
                 "--seed", "1",
                 "--force", "msa",
@@ -811,6 +811,7 @@ namespace ipk::ar
         ar_params.ar_model = parse_model(parameters.ar_model);
         ar_params.alpha = parameters.ar_alpha;
         ar_params.categories = parameters.ar_categories;
+        ar_params.num_threads = std::to_string(parameters.num_threads);
         ar_params.tree_file = ext_tree_file;
         ar_params.alignment_file = ext_alignment_phylip;
 

--- a/ipk/src/main.cpp
+++ b/ipk/src/main.cpp
@@ -178,7 +178,7 @@ return_code build_database(const ipk::cli::parameters& parameters)
 
     /// Prepare and run ancestral reconstruction
     auto [ar_software, ar_parameters] = ipk::ar::make_parameters(parameters,
-                                                                  extended_tree_file, ext_alignment_phylip);
+                                                                 extended_tree_file, ext_alignment_phylip);
     auto [proba_matrix, ar_tree] = ipk::ar::ancestral_reconstruction(ar_software, ar_parameters);
 
     if (parameters.ar_only)


### PR DESCRIPTION
When I get a error from raxml (e.g. about the tree being unrooted), it is buried in superfluous python error output.  This change will catch the subprocess.CalledProcessError in the python script so that this crap doesn't get printed.