### PR TITLE
Update ipk.py to avoid CPU oversubscription from raxml-ng side in bioconda recipe

### DIFF
--- a/ipk.py
+++ b/ipk.py
@@ -191,7 +191,7 @@ def validate_model(ctx, param, value):
               Saves time during database load and save, but requires more disk space.""")
 @click.option('--threads',
              type=int,
-             default=4, 
+             default=1, 
              show_default=True,
              help="Number of threads used to compute phylo-k-mers.")
 def build(ar,


### PR DESCRIPTION
**A fast fix to be bioconda recipe compatible.**

- makes ipk.py uses 1 thread by default
- as a consequence raxml-ng command that is launched is assigned to 1 CPU
- as a consequence, no crash related to raml-ng not allowing CPU oversubscription without specific debug options in the command-line.

**Long term fix:**

- Option 1 (fast): add the option `--force perf_threads` to the raxml-ng command generated by `ar::raxml_wrapper` and keep same number of threads as defined by ipk-* command. See https://github.com/amkozlov/raxml-ng/wiki/Parallelization

- Option 2 (harder): Make sure that ` ar::raxml_wrapper` do not assign to raxml-ng more CPU than what the local environment allows.