### PR TITLE
Include sstream to avoid clang compilation error (osx)

### DIFF
--- a/ipk/src/ar.cpp
+++ b/ipk/src/ar.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <numeric>
 #include <cmath>
 #include <string>


### PR DESCRIPTION
`ipk/src/ar.cpp` refuses to compile using clang (bioconda osx image).
```
17:18:39 BIOCONDA INFO (ERR) /opt/mambaforge/envs/bioconda/conda-bld/ipk_1708708439864/work/ipk/src/ar.cpp:127:36: error: implicit instantiation of undefined template **'std::basic_istringstream<char>'**
```

This error matches the following stackoverflow discussion, last comment explains that it is a clang issue.
https://stackoverflow.com/questions/61735609/implicit-instantiation-of-undefined-template-std-1basic-istringstreamchar

Adding `#include <sstream>` to `ar.cpp` solved the issue in my local build in an OSX VM.

@nromashchenko 
I wait for your approval before applying this as a patch to tag v0.5.0, this will allow me to achieve the bioconda recipe.
It has to be unix and osx compatible. Unix tests all passed, just need this last fix for osx.

Any other source file where you used `std::basic_istringstream<char>'` ?
